### PR TITLE
Shorten CI timeout based on test length

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,5 +6,5 @@ failure-output = "immediate-final"
 status-level = "skip"
 # Do not cancel the test run on the first failure.
 fail-fast = false
-# Mark tests as slow after 5mins, kill them after 50
-slow-timeout = { period = "300s", terminate-after = 10 }
+# Mark tests as slow after 5mins, kill them after 10
+slow-timeout = { period = "300s", terminate-after = 2 }


### PR DESCRIPTION
CI tests seem to each run under a minute based on https://github.com/lurk-lab/bellpepper-gadgets/actions/runs/6533972385/job/17740201030, so a shorter timeout seems appropriate.