### PR TITLE
chore: Add msrv to merkle-inclusion

### DIFF
--- a/crates/merkle-inclusion/Cargo.toml
+++ b/crates/merkle-inclusion/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Merkle proof of inclusion using Bellpepper"
 homepage.workspace = true
 repository.workspace = true
-rust-version = "1.70"
+rust-version = "1.71.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/merkle-inclusion/Cargo.toml
+++ b/crates/merkle-inclusion/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 description = "Merkle proof of inclusion using Bellpepper"
 homepage.workspace = true
 repository.workspace = true
+rust-version = "1.70"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
For fixing the [CI failure](https://github.com/lurk-lab/bellpepper-gadgets/actions/runs/7927883394/job/21645060081)

(I picked the default value from our rust template, but this could be different I suppose)

(PS: Sorry for the PR churn, I missed the CI failure in #29)