### PR TITLE
bellpepper-emulated: Fix constant bug in sub_op

### DIFF
--- a/crates/emulated/src/field_ops.rs
+++ b/crates/emulated/src/field_ops.rs
@@ -433,7 +433,7 @@ where
         if a.is_constant() && b.is_constant() {
             let a_int = BigInt::from(a);
             let b_int = BigInt::from(b);
-            let res_int = (a_int + b_int).rem(P::modulus());
+            let res_int = (a_int - b_int).rem(P::modulus());
             return Ok(Self::from(&res_int));
         }
 


### PR DESCRIPTION
Constant elements were not being subtracted properly. Noticed this by calling `.neg()` on a constant and seeing the result was equal to the input.