### PR TITLE
bellpepper-emulated: Fix and improve constant handling

### DIFF
--- a/crates/emulated/src/field_ops.rs
+++ b/crates/emulated/src/field_ops.rs
@@ -435,7 +435,7 @@ where
         if a.is_constant() && b.is_constant() {
             let a_int = BigInt::from(a);
             let b_int = BigInt::from(b);
-            let res_int = if a_int > b_int {
+            let res_int = if a_int >= b_int {
                 (a_int - b_int).rem(P::modulus())
             } else {
                 P::modulus() - (b_int - a_int).rem(P::modulus())

--- a/crates/emulated/src/field_ops.rs
+++ b/crates/emulated/src/field_ops.rs
@@ -9,7 +9,7 @@ use bellpepper_core::num::{AllocatedNum, Num};
 use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
 use ff::{PrimeField, PrimeFieldBits};
 use num_bigint::BigInt;
-use num_traits::{One, Zero};
+use num_traits::One;
 
 use crate::field_element::{EmulatedFieldElement, EmulatedFieldParams, EmulatedLimbs};
 use crate::util::{bigint_to_scalar, decompose, recompose};
@@ -435,11 +435,11 @@ where
         if a.is_constant() && b.is_constant() {
             let a_int = BigInt::from(a);
             let b_int = BigInt::from(b);
-            let mut res_int = a_int - b_int;
-            while res_int < BigInt::zero() {
-                res_int += P::modulus();
-            }
-            res_int = res_int.rem(P::modulus());
+            let res_int = if a_int > b_int {
+                (a_int - b_int).rem(P::modulus())
+            } else {
+                P::modulus() - (b_int - a_int).rem(P::modulus())
+            };
             return Ok(Self::from(&res_int));
         }
 


### PR DESCRIPTION
* Fix `sub_op` to actually subtract constants (it was just adding them together before)
* Only call fold_limbs in `mul` if the product result is not constant (this would fail because fold_limbs is not implemented for constants)
* Return early from `assert_is_equal` in the constant case (this would fail because compact_limbs is not implemented for constants)
* Add simple test covering these code paths

@avras: If there is a reason why `assert_is_equal` was falling through and continuing with the rest of the function in the constant if case, let me know. Since it was failing later on with "compact_limbs not implemented for constants", I modified it to return `Ok(())` before calling `assert_limbs_equality` and so on.

With this change, calling `assert_is_equal` with two constant elements will work correctly, and will NOT generate any constraints in the constraint system. I believe this is desirable behavior.