### PR TITLE
bls12381: Add support for point at infinity for G1 adds

### DIFF
--- a/crates/bls12381/src/curves/g1.rs
+++ b/crates/bls12381/src/curves/g1.rs
@@ -170,7 +170,7 @@ impl<F: PrimeField + PrimeFieldBits> G1Point<F> {
         let a_case = Boolean::and(
             &mut cs.namespace(|| "a_case <- and(a_is_0, b_eq_c)"),
             &Boolean::from(a_is_0.clone()),
-            &Boolean::from(b_eq_c),
+            &b_eq_c,
         )?;
         // if b == 0, then check a == c and ignore res
         let b_is_0 = b.alloc_is_identity(&mut cs.namespace(|| "b_is_0 <- b =? 0"))?;
@@ -184,7 +184,7 @@ impl<F: PrimeField + PrimeFieldBits> G1Point<F> {
         let b_case = Boolean::and(
             &mut cs.namespace(|| "b_case <- and(b_is_0, a_eq_c)"),
             &Boolean::from(b_is_0.clone()),
-            &Boolean::from(a_eq_c),
+            &a_eq_c,
         )?;
 
         let any_is_0 = Boolean::or(
@@ -287,14 +287,14 @@ impl<F: PrimeField + PrimeFieldBits> G1Point<F> {
         let res = Self::conditionally_select(
             &mut cs.namespace(|| "res <- select(res, q, sel1)"),
             &res,
-            &q,
+            q,
             &Boolean::from(sel1),
         )?;
         // if q=(0,0) return p
         let res = Self::conditionally_select(
             &mut cs.namespace(|| "res <- select(res, p, sel2)"),
             &res,
-            &p,
+            p,
             &Boolean::from(sel2),
         )?;
         // if p.y + q.y = 0, return (0, 0)
@@ -725,8 +725,15 @@ mod tests {
         let a_alloc = G1Point::alloc_element(&mut cs.namespace(|| "alloc a"), &a).unwrap();
         let b_alloc = G1Point::alloc_element(&mut cs.namespace(|| "alloc b"), &b).unwrap();
         let neg_a = a_alloc.neg(&mut cs.namespace(|| "-a")).unwrap();
-        let res_alloc = a_alloc.add_unified(&mut cs.namespace(|| "a-a"), &neg_a).unwrap();
-        G1Point::assert_is_equal(&mut cs.namespace(|| "a-a = 0"), &res_alloc, &G1Point::identity()).unwrap();
+        let res_alloc = a_alloc
+            .add_unified(&mut cs.namespace(|| "a-a"), &neg_a)
+            .unwrap();
+        G1Point::assert_is_equal(
+            &mut cs.namespace(|| "a-a = 0"),
+            &res_alloc,
+            &G1Point::identity(),
+        )
+        .unwrap();
         let zbit_alloc = res_alloc
             .alloc_is_identity(&mut cs.namespace(|| "z <- a-a ?= 0"))
             .unwrap();

--- a/crates/bls12381/src/curves/g1.rs
+++ b/crates/bls12381/src/curves/g1.rs
@@ -138,7 +138,7 @@ impl<F: PrimeField + PrimeFieldBits> G1Point<F> {
     where
         CS: ConstraintSystem<F>,
     {
-        // compute leftside = (y_a - y_c) * (x_b - x_a)
+        // compute leftside = (y_a + y_c) * (x_b - x_a)
         let aymcy = a.y.add(&mut cs.namespace(|| "aymcy <- a.y + c.y"), &c.y)?; // flip c.y to check for EC add
         let bxax = b.x.sub(&mut cs.namespace(|| "bxax <- b.x - a.x"), &a.x)?;
         let leftside = aymcy.mul(&mut cs.namespace(|| "leftside <- aymcy * bxax"), &bxax)?;


### PR DESCRIPTION
This PR adds some initial point at infinity handling for G1 points. (G2 points will be similar, but come in a future PR).

* Add `identity()` method that returns `(0, 0)`
* Check if value is identity inside `alloc_elem`: the native bls12_381 representation is `(0, 1)` instead of `(0, 0)`, so we need to map it
* Add `alloc_is_identity()` that checks whether the point is `(0, 0)`
* Modify `assert_collinear` into `assert_addition` that can handle points at infinity. Function is called with `assert_addition(a, b, c)` and checks whether `a + b = c` is valid
  * Supports the case where `a == 0` or `b == 0`, to support checking whether `a + b = c`: usually only one of `a` or `b` is `0`, and in this case then `c == 0` as well and the function works properly. The function only breaks if `b == -a` and `c == 0`.
  * The costs of this function are still under the costs of `add_unified` (~3800 vs ~5000 constraints per operation), so it makes sense to have it for certain applications for now.
  * The changes are implemented by chaining boolean conditions.
* Add `add_unified` implementation that supports all input values. (`p = 0`, `q = 0`, `p = q` are all supported)
* Add `conditionally_select` implementation for `G1Point`