### PR TITLE
chore: Refactor dependencies across workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
     open-pull-requests-limit: 5
 
   - package-ecosystem: "github-actions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,10 @@ pasta_curves = { version = "0.5", features = ["repr-c", "serde"] }
 rand = "0.8.5"
 rand_core = "0.6.4"
 rand_xorshift = "0.3.0"
+num-bigint = "0.4.3"
+num-integer = "0.1.45"
+num-traits = "0.2.15"
+proptest = "1.4.0"
 
 [profile.dev-ci]
 inherits = "dev"

--- a/crates/bls12381/Cargo.toml
+++ b/crates/bls12381/Cargo.toml
@@ -13,13 +13,12 @@ rust-version = "1.66.1"
 
 [dependencies]
 bellpepper-core = { workspace = true }
-bellpepper = { workspace = true }
 ff = { workspace = true }
 bellpepper-emulated = { version = "0.2.0", path = "../emulated" }
-num-bigint = { version = "0.4.3", features = ["rand"] }
-num-integer = "0.1.45"
-num-traits = "0.2.15"
-rand = "0.8.5"
+num-bigint = { workspace = true, features = ["rand"] }
+num-integer = { workspace = true }
+num-traits = { workspace = true}
+rand = { workspace = true}
 bls12_381 = { git = "https://github.com/wrinqle/bls12_381" }
 
 [dev-dependencies]

--- a/crates/chunk/Cargo.toml
+++ b/crates/chunk/Cargo.toml
@@ -13,8 +13,7 @@ repository.workspace = true
 
 [dependencies]
 anyhow = "1.0.40"
-bellpepper = { workspace = true }
-bellpepper-core = { git = "https://github.com/lurk-lab/bellpepper", branch = "dev", default-features = false }
+bellpepper-core = { workspace = true, default-features = false }
 ff = { workspace = true }
 thiserror = "1.0.57"
 getset = "0.1.2"

--- a/crates/ed25519/Cargo.toml
+++ b/crates/ed25519/Cargo.toml
@@ -12,12 +12,11 @@ rust-version = "1.66"
 
 [dependencies]
 bellpepper-core = { workspace = true }
-bellpepper = { workspace = true }
 ff = { workspace = true }
 bellpepper-emulated = { version = "0.2.0", path = "../emulated" }
-num-bigint = { version = "0.4.3", features = ["rand"] }
-num-integer = "0.1.45"
-num-traits = "0.2.15"
+num-bigint = { workspace = true, features = ["rand"] }
+num-integer = { workspace = true}
+num-traits = { workspace = true}
 rand = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/emulated/Cargo.toml
+++ b/crates/emulated/Cargo.toml
@@ -12,10 +12,9 @@ repository.workspace = true
 
 [dependencies]
 bellpepper-core = { workspace = true }
-bellpepper = { workspace = true }
 ff = { workspace = true }
-num-bigint = { version = "0.4.3", features = ["rand"] }
-num-traits = "0.2.15"
+num-bigint = { workspace = true, features = ["rand"] }
+num-traits = { workspace = true }
 
 [dev-dependencies]
 pasta_curves = { workspace = true }

--- a/crates/keccak/Cargo.toml
+++ b/crates/keccak/Cargo.toml
@@ -19,6 +19,6 @@ bitvec = "1.0.1"
 bls12_381 = "0.8.0"
 libsecp256k1 = "0.7"
 pairing = "0.23.0"
-proptest = "0.9.6"
+proptest = { workspace = true }
 tiny-keccak = { version = "2.0", features = ["keccak","sha3"] }
 hex = "0.4.3"

--- a/crates/merkle-inclusion/Cargo.toml
+++ b/crates/merkle-inclusion/Cargo.toml
@@ -13,7 +13,6 @@ rust-version = "1.71.1"
 
 [dependencies]
 bellpepper-core = { workspace = true }
-bellpepper = { workspace = true }
 digest = "0.11.0-pre.4"
 ff = { workspace = true }
 

--- a/crates/sha512/Cargo.toml
+++ b/crates/sha512/Cargo.toml
@@ -13,7 +13,6 @@ repository.workspace = true
 bellpepper-core = { workspace = true }
 bellpepper = { workspace = true }
 ff = { workspace = true }
-proptest = "1.4.0"
 
 [dev-dependencies]
 blstrs = "0.7.0"
@@ -24,3 +23,4 @@ rand_core = { workspace = true }
 rand_xorshift = { workspace = true }
 sha2 = "0.10.6"
 hex = "0.4.3"
+proptest = { workspace = true}


### PR DESCRIPTION
- Adjusted the `dependabot.yml` file to only update "minor" and "patch" in the "rust-dependencies" group.
- Removed `bellpepper` dependency from multiple crates, including `bls12381`, `ed25519`, `merkle-inclusion`, `emulated`, and `chunk`.
- Replaced specific version dependencies with workspace versions for `num-bigint`, `num-integer`, `num-traits`, and `rand` in various crates.
- Added dependencies `num-bigint`, `num-integer`, `num-traits`, and `proptest` in the main `Cargo.toml` file.
- Switched `proptest` and `bellpepper-core` dependencies to use the workspace version in `sha512` and `chunk` crates respectively.