### PR TITLE
chore: Update MIT license link in READMEs

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -4,5 +4,5 @@ progress = false
 # Exclude URLs from checking (supports regex)
 exclude = [
     # rate-limit doesn't play well with our crate structure
-    "http://opensource.org/licenses/MIT",
+    "https://opensource.org/blog/license/MIT",
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -4,5 +4,5 @@ progress = false
 # Exclude URLs from checking (supports regex)
 exclude = [
     # rate-limit doesn't play well with our crate structure
-    "https://opensource.org/blog/license/MIT",
+    "https://opensource.org/license/MIT",
 ]

--- a/crates/bls12381/README.md
+++ b/crates/bls12381/README.md
@@ -9,7 +9,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/MIT)
 
 at your option.
 

--- a/crates/bls12381/README.md
+++ b/crates/bls12381/README.md
@@ -9,7 +9,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
 
 at your option.
 

--- a/crates/ed25519/README.md
+++ b/crates/ed25519/README.md
@@ -10,7 +10,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
 
 at your option.
 

--- a/crates/ed25519/README.md
+++ b/crates/ed25519/README.md
@@ -10,7 +10,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/MIT)
 
 at your option.
 

--- a/crates/emulated/README.md
+++ b/crates/emulated/README.md
@@ -9,7 +9,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/MIT)
 
 at your option.
 

--- a/crates/emulated/README.md
+++ b/crates/emulated/README.md
@@ -9,7 +9,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
 
 at your option.
 

--- a/crates/keccak/README.md
+++ b/crates/keccak/README.md
@@ -9,7 +9,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/MIT)
 
 at your option.
 

--- a/crates/keccak/README.md
+++ b/crates/keccak/README.md
@@ -9,7 +9,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
 
 at your option.
 

--- a/crates/sha1/README.md
+++ b/crates/sha1/README.md
@@ -8,7 +8,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/MIT)
 
 at your option.
 

--- a/crates/sha1/README.md
+++ b/crates/sha1/README.md
@@ -8,7 +8,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
 
 at your option.
 

--- a/crates/sha512/README.md
+++ b/crates/sha512/README.md
@@ -13,7 +13,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
 
 at your option.
 

--- a/crates/sha512/README.md
+++ b/crates/sha512/README.md
@@ -13,7 +13,7 @@ Licensed under either of
  * Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
  * MIT license
-   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/blog/license/MIT)
+   ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/license/MIT)
 
 at your option.
 


### PR DESCRIPTION
Earlier today opensource.org went down for scheduled maintenance, and now the previous http://opensource.org/licenses/MIT links are returning 404, leading to CI failures.

Seems like it moved to https://opensource.org/blog/license/MIT