### PR TITLE
chore: Use lurk-lab fork of bls12_381

### DIFF
--- a/crates/bls12381/Cargo.toml
+++ b/crates/bls12381/Cargo.toml
@@ -19,7 +19,7 @@ num-bigint = { workspace = true, features = ["rand"] }
 num-integer = { workspace = true }
 num-traits = { workspace = true}
 rand = { workspace = true}
-bls12_381 = { git = "https://github.com/wrinqle/bls12_381", features = ["experimental"] }
+bls12_381 = { git = "https://github.com/lurk-lab/bls12_381", features = ["experimental"] }
 
 [dev-dependencies]
 expect-test = "1.4.1"

--- a/deny.toml
+++ b/deny.toml
@@ -265,7 +265,7 @@ allow-git = []
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = ["lurk-lab", "wrinqle"]
+github = ["lurk-lab"]
 # 1 or more gitlab.com organizations to allow git sources for
 # gitlab = [""]
 # 1 or more bitbucket.org organizations to allow git sources for


### PR DESCRIPTION
Closes #21

The bls12_381 fork is now hosted [here](https://github.com/lurk-lab/bls12_381), with the same commits to the main branch.