### PR TITLE
bellpepper-emulated: Avoid AssignmentMissing error when using MetricCS

### DIFF
--- a/crates/ed25519/Cargo.toml
+++ b/crates/ed25519/Cargo.toml
@@ -25,3 +25,4 @@ getrandom = { version = "0.2.0", default-features = false, features = ["js"] }
 
 [dev-dependencies]
 pasta_curves = { workspace = true }
+bellpepper = { workspace = true }


### PR DESCRIPTION
The changes in this PR are the following:

- Add a scalar multiplication test in `ed25519` that uses `MetricCS` 
- Avoid returning `SynthesisError::AssignmentMissing` in `alloc_num_equals_constant`
- Avoid returning `SynthesisError::AssignmentMissing` in `conditionally_select`

`ed25519` scalar multiplication using `MetricCS` fails with an `AssignmentMissing` error. 

In `emulated/src/util.rs:alloc_num_equals_constant`, the function was returning `SynthesisError::AssignmentMissing` when used with `MetricCS`.  The input `a` returned `None` for `a.get_value()`. An `emulated` library user also reported synthesis errors at this juncture.

After fixing the above, the `AssignmentMissing` error occurred in `emulated/src/field_element.rs:conditionally_select`. The below comment does not hold if `condition` is set to a `Boolean::Constant`.  So `condition` could have a value when used with `MetricCS` but the limbs may not have values.
```
  // If the condition has a value, then the limbs must also have a value, so we bubble
  // the assignment missing error in this case
```
For example, in `ed25519` scalar multiplication, the bits corresponding to the scalar can be constant `Boolean`s. It is possible a fixed group element is being calculated in the circuit.